### PR TITLE
Remove duplicate viewport tags and old jQuery

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,6 @@
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.teal-orange.min.css" />
   <link rel="stylesheet" href="styles.css" />
   <meta name="description" content="">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="">
   <meta property="og:type" content="">
   <meta property="og:url" content="">
@@ -58,7 +57,6 @@
   <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-  <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
   <script src="../js/plugins.js"></script>
   <script src="../js/main.js"></script>
   <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">

--- a/public/projects/phys319/index.html
+++ b/public/projects/phys319/index.html
@@ -10,7 +10,6 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue_grey-deep_orange.min.css" />
   <meta name="description" content="">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="">
   <meta property="og:type" content="">
   <meta property="og:url" content="">
@@ -32,7 +31,6 @@
 <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="js/plugins.js"></script>
 <script src="js/main.js"></script>
 <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">

--- a/public/projects/phys404/index.html
+++ b/public/projects/phys404/index.html
@@ -10,7 +10,6 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.teal-orange.min.css" />
   <meta name="description" content="">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="">
   <meta property="og:type" content="">
   <meta property="og:url" content="">
@@ -32,7 +31,6 @@
 <script src="https://code.getmdl.io/1.3.0/material.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-<script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
 <script src="js/plugins.js"></script>
 <script src="js/main.js"></script>
 <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">


### PR DESCRIPTION
## Summary
- cleanup duplicate `<meta name="viewport">` tags
- remove jQuery 2.1.1 references so each page uses jQuery 3.3.1 once

## Testing
- `python3 -m http.server 8000 --directory public` (manual)
- `curl -s http://localhost:8000/index.html | grep -o "jquery.min.js" | wc -l`
- `curl -s http://localhost:8000/projects/phys319/index.html | grep -o "jquery.min.js" | wc -l`
- `curl -s http://localhost:8000/projects/phys404/index.html | grep -o "jquery.min.js" | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_6843a996b1848321a0c88161487c032a