### PR TITLE
Improve home page design

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,9 @@
   <link
     href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en"
     rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
+    rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.teal-orange.min.css" />
   <link rel="stylesheet" href="styles.css" />

--- a/public/styles.css
+++ b/public/styles.css
@@ -2,8 +2,8 @@
 /*https://material.io/guidelines/style/color.html#color-color-palette*/
 
 body {
-  background-color: #ECEFF1;
-  font-family: Roboto, sans-serif;
+  background: linear-gradient(135deg, #fdfbfb 0%, #ebedee 100%);
+  font-family: 'Poppins', 'Roboto', sans-serif;
 }
 
 h1 {
@@ -44,7 +44,7 @@ p {
 .header {
   width: 100%;
   height: 10%;
-  background-color: #607D8B;
+  background: linear-gradient(90deg, #546e7a, #455a64);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -66,7 +66,7 @@ p {
 .footer {
   width: 100%;
   height: 10%;
-  background-color: #607D8B;
+  background: linear-gradient(90deg, #546e7a, #455a64);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -140,4 +140,14 @@ p {
   font-size: 14px;
   margin-top: 5px; /* Reduced top margin */
     margin-bottom: 5px; /* Reduced bottom margin */
+}
+
+/* subtle lift when hovering over cards */
+.mdl-card {
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.mdl-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
## Summary
- add Poppins font to index page
- modernize page background and header/footer gradients
- add interactive card hover effect for material design cards

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6843abfac3d88321a21efacdd102497e