### PR TITLE
Improve SEO with meta updates and sitemap

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,7 +26,7 @@
 #     Instead of using this file, consider using a specific rule such as
 #     allowing access based on (sub)domain:
 #
-#         Header set Access-Control-Allow-Origin "subdomain.example.com"
+#         Header set Access-Control-Allow-Origin "subdomain.ashtanmistal.com"
 
 # <IfModule mod_headers.c>
 #     Header set Access-Control-Allow-Origin "*"
@@ -347,7 +347,7 @@ AddDefaultCharset utf-8
 # | Suppressing the `www.` at the beginning of URLs                    |
 # ----------------------------------------------------------------------
 
-# Rewrite www.example.com → example.com
+# Rewrite www.ashtanmistal.com → ashtanmistal.com
 
 # The same content should never be available under two different URLs,
 # especially not with and without `www.` at the beginning.
@@ -388,7 +388,7 @@ AddDefaultCharset utf-8
 # | Forcing the `www.` at the beginning of URLs                        |
 # ----------------------------------------------------------------------
 
-# Rewrite example.com → www.example.com
+# Rewrite ashtanmistal.com → www.ashtanmistal.com
 
 # The same content should never be available under two different URLs,
 # especially not with and without `www.` at the beginning.
@@ -618,7 +618,7 @@ AddDefaultCharset utf-8
 
 # Force client-side TLS (Transport Layer Security) redirection.
 #
-# If a user types `example.com` in their browser, even if the server redirects
+# If a user types `ashtanmistal.com` in their browser, even if the server redirects
 # them to the secure version of the website, that still leaves a window of
 # opportunity (the initial HTTP connection) for an attacker to downgrade or
 # redirect the request.
@@ -1022,7 +1022,7 @@ ServerSignature Off
 #     (e.g. users on a 2G connection).
 #
 #     You can test the effects of content transformation applied by
-#     Google's Lite Mode by visiting: https://googleweblight.com/i?u=https://www.example.com
+#     Google's Lite Mode by visiting: https://googleweblight.com/i?u=https://www.ashtanmistal.com
 #
 #     https://support.google.com/webmasters/answer/6211428
 #

--- a/doc/extend.md
+++ b/doc/extend.md
@@ -62,7 +62,7 @@ or a CDN that hosts content that may not be present on every page of your site,
 for example) then you can queue up a domain name to be prefetched.
 
 ```html
-<link rel="dns-prefetch" href="//example.com">
+<link rel="dns-prefetch" href="//ashtanmistal.com">
 <link rel="dns-prefetch" href="https://ajax.googleapis.com">
 ```
 
@@ -219,10 +219,10 @@ mouse over your Pinned Site's icon.
 If the site should go to a specific URL when it is pinned (such as the
 homepage), enter it here. One idea is to send it to a special URL so you can
 track the number of pinned users, like so:
-`https://www.example.com/index.html?pinned=true`
+`https://www.ashtanmistal.com/index.html?pinned=true`
 
 ```html
-<meta name="msapplication-starturl" content="https://www.example.com/index.html?pinned=true">
+<meta name="msapplication-starturl" content="https://www.ashtanmistal.com/index.html?pinned=true">
 ```
 
 ### Recolor IE's controls manually for a Pinned Site
@@ -281,7 +281,7 @@ schema](https://docs.microsoft.com/en-us/archive/blogs/ie/pinned-sites-in-window
   values](https://docs.microsoft.com/en-us/uwp/schemas/tiles/badgeschema/element-badge)
 
 ```html
-<meta name="msapplication-badge" value="frequency=NUMBER_IN_MINUTES;polling-uri=https://www.example.com/path/to/file.xml">
+<meta name="msapplication-badge" value="frequency=NUMBER_IN_MINUTES;polling-uri=https://www.ashtanmistal.com/path/to/file.xml">
 ```
 
 ## Search
@@ -297,7 +297,7 @@ Submit it to search engine tool:
 * [Baidu](https://zhanzhang.baidu.com/) OR Insert the following line anywhere in
   your robots.txt file, specifying the path to your sitemap:
 ```
-Sitemap: https://example.com/sitemap_location.xml
+Sitemap: https://ashtanmistal.com/sitemap_location.xml
 ```
 
 ### Hide pages from search engines
@@ -409,10 +409,10 @@ Facebook).
 
 ```html
 <meta property="fb:app_id" content="123456789">
-<meta property="og:url" content="https://www.example.com/path/to/page.html">
+<meta property="og:url" content="https://www.ashtanmistal.com/path/to/page.html">
 <meta property="og:type" content="website">
 <meta property="og:title" content="">
-<meta property="og:image" content="https://www.example.com/path/to/image.jpg">
+<meta property="og:image" content="https://www.ashtanmistal.com/path/to/image.jpg">
 <meta property="og:description" content="">
 <meta property="og:site_name" content="">
 <meta property="article:author" content="">
@@ -433,10 +433,10 @@ Twitter).
 <meta name="twitter:card" content="summary">
 <meta name="twitter:site" content="@site_account">
 <meta name="twitter:creator" content="@individual_account">
-<meta name="twitter:url" content="https://www.example.com/path/to/page.html">
+<meta name="twitter:url" content="https://www.ashtanmistal.com/path/to/page.html">
 <meta name="twitter:title" content="">
 <meta name="twitter:description" content="">
-<meta name="twitter:image" content="https://www.example.com/path/to/image.jpg">
+<meta name="twitter:image" content="https://www.ashtanmistal.com/path/to/image.jpg">
 ```
 
 ### Schema.org
@@ -470,8 +470,8 @@ note that this markup requires to add attributes to your top `html` tag.
 
 Signal to search engines and others "Use this URL for this page!" Useful when
 parameters after a `#` or `?` is used to control the display state of a page.
-`https://www.example.com/cart.html?shopping-cart-open=true` can be indexed as
-the cleaner, more accurate `https://www.example.com/cart.html`.
+`https://www.ashtanmistal.com/cart.html?shopping-cart-open=true` can be indexed as
+the cleaner, more accurate `https://www.ashtanmistal.com/cart.html`.
 
 ```html
 <link rel="canonical" href="">
@@ -489,12 +489,12 @@ This can be done by adding the following annotations in your HTML pages:
   corresponding mobile URL, e.g.:
 
   `<link rel="alternate" media="only screen and (max-width: 640px)"
-  href="https://m.example.com/page.html" >`
+  href="https://m.ashtanmistal.com/page.html" >`
 
 * on the mobile page, add the `link rel="canonical"` tag pointing to the
   corresponding desktop URL, e.g.:
 
-  `<link rel="canonical" href="https://www.example.com/page.html">`
+  `<link rel="canonical" href="https://www.ashtanmistal.com/page.html">`
 
 For more information please see:
 

--- a/public/index.html
+++ b/public/index.html
@@ -31,8 +31,9 @@
   <meta name="description" content="Portfolio of Ashtan Mistal, a C/C++ software engineer focused on 3D computer vision and geometric modeling.">
   <meta property="og:title" content="Ashtan Mistal - Software Engineer">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="">
-  <meta property="og:image" content="">
+  <meta property="og:url" content="https://ashtanmistal.com/">
+  <meta property="og:image" content="android-chrome-512x512.png">
+<link rel="canonical" href="https://ashtanmistal.com/">
 
   <link rel="manifest" href="site.webmanifest">
   <link rel="apple-touch-icon" href="apple-touch-icon.png">
@@ -90,7 +91,7 @@
                   <div class="mdl-card mdl-cell mdl-cell--12-col mdl-cell--9-col-desktop mdl-cell--6-col-tablet mdl-cell--4-col-phone">
                     <div class="mdl-card__supporting-text">
                       <div class="title-name">
-                        <h4>Ashtan Mistal</h4>
+                        <h1>Ashtan Mistal</h1>
                       </div>
                         Hello! I'm Ashtan <span style="white-space:nowrap;">(he/him)</span>. I'm a software engineer specializing in C/C++ for 3D computer vision and geometric modeling. I earned a BSc in Physics and Computer Science from UBC and now build high-performance vision tools at Polyga. My personal projects explore LiDAR data processing and 3D reconstruction.
                         Check out my <a href="https://www.github.com/ashtanmistal/MinecraftUBC">MinecraftUBC project</a> for a fun example of this work.
@@ -238,7 +239,7 @@
   </div>
   <div class="mdl-card__media">
     <a href="https://github.com/ashtanmistal/minecraftUBC">
-      <img class="article-image" style="max-width:100%; height:auto;" src="https://github.com/ashtanmistal/minecraftUBC/blob/master/docs/screenshots/Version-3.0/2024-06-14_10.54.44.png?raw=true" border="0" alt="">
+      <img class="article-image" style="max-width:100%; height:auto;" src="https://github.com/ashtanmistal/minecraftUBC/blob/master/docs/screenshots/Version-3.0/2024-06-14_10.54.44.png?raw=true" border="0" alt="Screenshot of UBC campus built in Minecraft">
     </a>
   </div>
   
@@ -272,7 +273,7 @@
         </div>
           <div class="mdl-card__media">
             <a href="https://github.com/ashtanmistal/Forest-Friends">
-              <img class="article-image" style="max-width:100%; height:auto;" src="https://github.com/ashtanmistal/minecraftUBC/blob/master/docs/screenshots/Version-3.0/forestfriends.png?raw=true" border="0" alt="">
+              <img class="article-image" style="max-width:100%; height:auto;" src="https://github.com/ashtanmistal/minecraftUBC/blob/master/docs/screenshots/Version-3.0/forestfriends.png?raw=true" border="0" alt="Forest Friends game screenshot">
             </a>
           </div>
           <div class="mdl-card__supporting-text padding-top">
@@ -306,7 +307,7 @@ analysis, adapting the theoretical model to retain voxel accuracy and reducing r
   </div>
     <div class="mdl-card__media">
       <a href="https://github.com/ashtanmistal/LiDAR-DenseSeg">
-        <img class="article-image" style="max-width:100%; height:auto;" src="https://github.com/ashtanmistal/LiDAR-DenseSeg/blob/main/paper/pipeline.png?raw=true" border="0" alt="">
+        <img class="article-image" style="max-width:100%; height:auto;" src="https://github.com/ashtanmistal/LiDAR-DenseSeg/blob/main/paper/pipeline.png?raw=true" border="0" alt="LiDAR-DenseSeg pipeline diagram">
       </a>
     </div>
     <div class="mdl-card__supporting-text padding-top">
@@ -336,7 +337,7 @@ analysis, adapting the theoretical model to retain voxel accuracy and reducing r
   </div>
   <!-- <div class="mdl-card__media">
     <a href="#">
-      <img class="article-image" style="max-width:100%; height:auto;" src="409.png" border="0" alt="">
+      <img class="article-image" style="max-width:100%; height:auto;" src="409.png" border="0" alt="PET image reconstruction sample">
     </a>
   </div> -->
   <div class="mdl-card__supporting-text no-bottom-padding">
@@ -358,7 +359,7 @@ analysis, adapting the theoretical model to retain voxel accuracy and reducing r
     <h2 class="mdl-card__title-text">Jotmark</h2>
   </div>
   <!-- <div class="mdl-card__media">
-    <a href="#"> <img class="article-image" src="images/jotmark.jpg" border="0" alt=""></a>
+    <a href="#"> <img class="article-image" src="images/jotmark.jpg" border="0" alt="Jotmark project screenshot"></a>
   </div> -->
   <div class="mdl-card__supporting-text no-bottom-padding">
     <span>Dec 2022 - Jan 2023</span>
@@ -382,7 +383,7 @@ analysis, adapting the theoretical model to retain voxel accuracy and reducing r
     <h2 class="mdl-card__title-text">Teaching Computer Graphics</h2>
   </div>
   <!-- <div class="mdl-card__media">
-    <a href="#"> <img class="article-image" src="images/teaching-computer-graphics.jpg" border="0" alt=""></a>
+    <a href="#"> <img class="article-image" src="images/teaching-computer-graphics.jpg" border="0" alt="Teaching computer graphics screenshot"></a>
   </div> -->
   <div class="mdl-card__supporting-text no-bottom-padding">
     <span>Sep 2022 - Apr 2023</span>

--- a/public/projects/phys319/index.html
+++ b/public/projects/phys319/index.html
@@ -9,11 +9,12 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue_grey-deep_orange.min.css" />
-  <meta name="description" content="">
-  <meta property="og:title" content="">
-  <meta property="og:type" content="">
-  <meta property="og:url" content="">
-  <meta property="og:image" content="">
+  <meta name="description" content="Monophonic synthesizer built with MSP430 microcontroller for PHYS 319.">
+  <meta property="og:title" content="Monophonic Synthesizer - PHYS 319">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ashtanmistal.com/projects/phys319/">
+  <meta property="og:image" content="../../android-chrome-512x512.png">
+<link rel="canonical" href="https://ashtanmistal.com/projects/phys319/">
 
   <link rel="manifest" href="../../public/site.webmanifest">
   <link rel="apple-touch-icon" href="../../public/icon.png">

--- a/public/projects/phys404/index.html
+++ b/public/projects/phys404/index.html
@@ -9,11 +9,12 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.teal-orange.min.css" />
-  <meta name="description" content="">
-  <meta property="og:title" content="">
-  <meta property="og:type" content="">
-  <meta property="og:url" content="">
-  <meta property="og:image" content="">
+  <meta name="description" content="Monte Carlo simulation project for radiation room shielding.">
+  <meta property="og:title" content="Radiation Room Shielding - PHYS 404">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ashtanmistal.com/projects/phys404/">
+  <meta property="og:image" content="img.png">
+<link rel="canonical" href="https://ashtanmistal.com/projects/phys404/">
 
   <link rel="manifest" href="../../public/site.webmanifest">
   <link rel="apple-touch-icon" href="../../public/icon.png">

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,4 @@
 # Allow crawling of all content
 User-agent: *
 Disallow:
+Sitemap: https://ashtanmistal.com/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,21 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Ashtan Mistal Portfolio",
+  "short_name": "Ashtan",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone",
+  "start_url": "/",
+  "description": "Portfolio website for Ashtan Mistal."
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ashtanmistal.com/</loc>
+  </url>
+  <url>
+    <loc>https://ashtanmistal.com/projects/phys319/</loc>
+  </url>
+  <url>
+    <loc>https://ashtanmistal.com/projects/phys404/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add alt text to images on the main page
- include canonical and Open Graph meta tags
- set descriptions on project pages
- add site information to the web manifest
- generate a sitemap and reference it in `robots.txt`
- replace example.com references with ashtanmistal.com

## Testing
- `npm --prefix public test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843cb23279c8321b741706ba0a5dc8b